### PR TITLE
Add exclude option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,23 @@ var out = postcss().use(prefix({
 console.log(out)
 ```
 
+## Options
+
+It's possible to avoid prefixing some selectors with the option `exclude` which take an array of selectors in parameter.
+
+```js
+var css = '.a {} \nhtml{} \n.b{}'
+
+var prefix = require('postcss-prefix-selector')
+
+var out = postcss().use(prefix({
+  prefix: '.some-selector ', // <--- notice the traililng space!
+  exclude: ['html', '.b']
+})).process(css).css
+
+console.log(out)
+```
+
 [gitter-image]: https://badges.gitter.im/jonathanong/postcss-prefix-selector.png
 [gitter-url]: https://gitter.im/jonathanong/postcss-prefix-selector
 [npm-image]: https://img.shields.io/npm/v/postcss-prefix-selector.svg?style=flat-square

--- a/index.js
+++ b/index.js
@@ -11,6 +11,9 @@ module.exports = function (options) {
       // pretty sure this splitting breaks for certain selectors
       var selectors = rule.selector.split(/\s*,\s*/g)
       rule.selector = selectors.map(function (selector) {
+        if (options.exclude && ~options.exclude.indexOf(selector)) {
+          return selector;
+        }
         return prefix + selector
       }).join(', ')
     })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "postcss-prefix-selector",
   "description": "Prefix all CSS rules with a selector",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": "Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)",
   "license": "MIT",
   "repository": "jonathanong/postcss-prefix-selector",

--- a/test/test.js
+++ b/test/test.js
@@ -21,3 +21,16 @@ it('should prefix a group of selectors', function () {
   assert(~out.indexOf('.hello .a'))
   assert(~out.indexOf('.hello .b'))
 })
+
+it('should avoid prefixing excluded selectors', function () {
+  var out = postcss().use(prefix({
+    prefix: '.hello ',
+    exclude: ['body', '.a *:not(.b)']
+  })).process('.a, .b {}\n body {}\n .a *:not(.b) {}\n .c {}').css
+
+  assert(~out.indexOf('.hello .a'))
+  assert(~out.indexOf('.hello .b'))
+  assert(~out.indexOf('.hello .c'))
+  assert(out.indexOf('.hello body'))
+  assert(out.indexOf('.hello .a *:not(.b)'))
+})


### PR DESCRIPTION
Add `exclude` option to avoid prefixing some selectors

Usage:

```
var css = '.a {} \nhtml{} \n.b{}'

var prefix = require('postcss-prefix-selector')

var out = postcss().use(prefix({
  prefix: '.some-selector ', // <--- notice the traililng space!
  exclude: ['html', '.b']
})).process(css).css

console.log(out) // only .a selector will be prefixed
```

Bump version to 1.2.0