### PR TITLE
Added support for replacing html and body in selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ var prefix = require('postcss-prefix-selector')
 var css = fs.readFileSync("input.css", "utf8")
 
 var out = postcss().use(prefix({
-  prefix: '.some-selector ', // <--- notice the traililng space!
+  prefix: '.some-selector',
   exclude: ['.c']
 })).process(css).css
 ```

--- a/index.js
+++ b/index.js
@@ -3,9 +3,8 @@ var assert = require('assert')
 
 module.exports = function (options) {
   assert(options)
-  var prefix = options.prefix
+  var prefix = options.prefix.trim() // trim as we no longer need a space in the options
   assert(prefix)
-  if (!/\s+$/.test(prefix)) prefix += ' '
   return function (root) {
     root.walkRules(function (rule) {
       if (rule.parent && rule.parent.name == 'keyframes') {
@@ -13,10 +12,20 @@ module.exports = function (options) {
       }
 
       rule.selectors = rule.selectors.map(function (selector) {
+        // IF THE SELECTOR IS EXCLUDED, DO EARLY RETURNS
         if (options.exclude && excludeSelector(selector, options.exclude)) {
           return selector
         }
-        return prefix + selector
+
+        // REPLACE DESCENDANT COMBINATORS THAT CAN'T BE PREFIXED
+        selector = selector.replace(/^html body|^html|^body/, '').trim()
+
+        if (!selector.length) {
+          // avoid double spaces when selector length is zero
+          return prefix
+        }
+
+        return prefix + ' ' + selector
       })
     })
   }

--- a/index.js
+++ b/index.js
@@ -25,6 +25,11 @@ module.exports = function (options) {
           return prefix
         }
 
+        if (/^:/.test(selector)) {
+          // ensure there is no space for pseudo element selectors
+          return prefix + selector
+        }
+
         return prefix + ' ' + selector
       })
     })

--- a/index.js
+++ b/index.js
@@ -25,6 +25,12 @@ module.exports = function (options) {
           return prefix
         }
 
+        if (selector.indexOf(' body') >= 0) {
+          // there are cases where body might part of a decendant selector, so we do a replace instead
+          selector = selector.replace('body', prefix);
+          return  selector
+        }
+
         if (/^:/.test(selector)) {
           // ensure there is no space for pseudo element selectors
           return prefix + selector

--- a/index.js
+++ b/index.js
@@ -31,6 +31,12 @@ module.exports = function (options) {
           return selector;
         }
 
+        if (/^.ad-container/.test(selector)) {
+          // this is a HACK
+          selector = selector.replace('.ad-container', '.ad-container ' + prefix);
+          return selector;
+        }
+
         if (/^:/.test(selector)) {
           // ensure there is no space for pseudo element selectors
           return prefix + selector

--- a/index.js
+++ b/index.js
@@ -26,9 +26,9 @@ module.exports = function (options) {
         }
 
         if (selector.indexOf(' body') >= 0) {
-          // there are cases where body might part of a decendant selector, so we do a replace instead
+          // there are cases where body might be a part of a decendant selector, so we do a replace instead
           selector = selector.replace('body', prefix);
-          return  selector
+          return selector;
         }
 
         if (/^:/.test(selector)) {

--- a/test/fixtures/replace-selectors.css
+++ b/test/fixtures/replace-selectors.css
@@ -52,3 +52,13 @@ html body:after {
   margin: 0;
   padding: 0;
 }
+
+.friend body {
+    margin: 0;
+    padding: 0;
+}
+
+.friend body:after {
+    margin: 0;
+    padding: 0;
+}

--- a/test/fixtures/replace-selectors.css
+++ b/test/fixtures/replace-selectors.css
@@ -1,0 +1,39 @@
+html {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+}
+
+html body {
+  margin: 0;
+  padding: 0;
+}
+
+html .friend {
+  margin: 0;
+  padding: 0;
+}
+
+html.friend {
+  margin: 0;
+  padding: 0;
+}
+
+html body.friend {
+  margin: 0;
+  padding: 0;
+}
+
+body .friend {
+  margin: 0;
+  padding: 0;
+}
+
+body.friend {
+  margin: 0;
+  padding: 0;
+}

--- a/test/fixtures/replace-selectors.css
+++ b/test/fixtures/replace-selectors.css
@@ -37,3 +37,18 @@ body.friend {
   margin: 0;
   padding: 0;
 }
+
+html:after {
+  margin: 0;
+  padding: 0;
+}
+
+body:after {
+  margin: 0;
+  padding: 0;
+}
+
+html body:after {
+  margin: 0;
+  padding: 0;
+}

--- a/test/fixtures/replace-selectors.expected.css
+++ b/test/fixtures/replace-selectors.expected.css
@@ -1,0 +1,39 @@
+.hello {
+  margin: 0;
+  padding: 0;
+}
+
+.hello {
+  margin: 0;
+  padding: 0;
+}
+
+.hello {
+  margin: 0;
+  padding: 0;
+}
+
+.hello .friend {
+  margin: 0;
+  padding: 0;
+}
+
+.hello .friend {
+  margin: 0;
+  padding: 0;
+}
+
+.hello .friend {
+  margin: 0;
+  padding: 0;
+}
+
+.hello .friend {
+  margin: 0;
+  padding: 0;
+}
+
+.hello .friend {
+  margin: 0;
+  padding: 0;
+}

--- a/test/fixtures/replace-selectors.expected.css
+++ b/test/fixtures/replace-selectors.expected.css
@@ -52,3 +52,13 @@
   margin: 0;
   padding: 0;
 }
+
+.friend .hello {
+    margin: 0;
+    padding: 0;
+}
+
+.friend .hello:after {
+    margin: 0;
+    padding: 0;
+}

--- a/test/fixtures/replace-selectors.expected.css
+++ b/test/fixtures/replace-selectors.expected.css
@@ -37,3 +37,18 @@
   margin: 0;
   padding: 0;
 }
+
+.hello:after {
+  margin: 0;
+  padding: 0;
+}
+
+.hello:after {
+  margin: 0;
+  padding: 0;
+}
+
+.hello:after {
+  margin: 0;
+  padding: 0;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -7,7 +7,7 @@ var prefix = require('..')
 
 it('should prefix a selector', function () {
   var out = postcss().use(prefix({
-    prefix: '.hello '
+    prefix: '.hello'
   })).process(getFixtureContents('single-selector.css')).css
 
   var expected = getFixtureContents('single-selector.expected.css')
@@ -17,7 +17,7 @@ it('should prefix a selector', function () {
 
 it('should prefix a group of selectors', function () {
   var out = postcss().use(prefix({
-    prefix: '.hello '
+    prefix: '.hello'
   })).process(getFixtureContents('group-selectors.css')).css
 
   var expected = getFixtureContents('group-selectors.expected.css')
@@ -27,7 +27,7 @@ it('should prefix a group of selectors', function () {
 
 it('should avoid prefixing excluded selectors', function () {
   var out = postcss().use(prefix({
-    prefix: '.hello ',
+    prefix: '.hello',
     exclude: ['body', '.a *:not(.b)', /class-/]
   })).process(getFixtureContents('exclude-selectors.css')).css
 
@@ -38,10 +38,20 @@ it('should avoid prefixing excluded selectors', function () {
 
 it('should skip @keyframes selectors', function () {
   var out = postcss().use(prefix({
-    prefix: '.hello '
+    prefix: '.hello'
   })).process(getFixtureContents('keyframes.css')).css
 
   var expected = getFixtureContents('keyframes.expected.css')
+
+  assert.equal(out, expected)
+})
+
+it('should replace selectors and combinators that should not be prefixed', function () {
+  var out = postcss().use(prefix({
+    prefix: '.hello'
+})).process(getFixtureContents('replace-selectors.css')).css
+
+  var expected = getFixtureContents('replace-selectors.expected.css')
 
   assert.equal(out, expected)
 })


### PR DESCRIPTION
Selectors equal to and containing html and body should be replaced and not be prefixed in the normal manner.  Also, I removed the need for the trailing space in options.